### PR TITLE
Expose Get Media Tracks of localStream in publisher

### DIFF
--- a/dist/publisher/index.d.ts
+++ b/dist/publisher/index.d.ts
@@ -59,4 +59,5 @@ export declare class WebRTCPublisher {
     private _reportError;
     disconnect(): Promise<void>;
     private _stopStream;
+    getStreamTracks(type: 'video' | 'audio' | 'all'): MediaStreamTrack[];
 }

--- a/dist/publisher/index.js
+++ b/dist/publisher/index.js
@@ -614,6 +614,19 @@ var WebRTCPublisher = /** @class */ (function () {
             utils_1.cnsl.log('[Publisher] Unbind local stream');
         }
     };
+    WebRTCPublisher.prototype.getStreamTracks = function (type) {
+        if (!this.localStream) {
+            throw new Error("No stream defined");
+        }
+        switch (type) {
+            case 'video':
+                return this.localStream.getVideoTracks();
+            case 'audio':
+                return this.localStream.getAudioTracks();
+            case 'all':
+                return this.localStream.getTracks();
+        }
+    };
     return WebRTCPublisher;
 }());
 exports.WebRTCPublisher = WebRTCPublisher;

--- a/lib/publisher/index.ts
+++ b/lib/publisher/index.ts
@@ -503,4 +503,18 @@ export class WebRTCPublisher {
       cnsl.log('[Publisher] Unbind local stream')
     }
   }
+
+  public getStreamTracks(type: 'video' | 'audio' | 'all'): MediaStreamTrack[]{
+    if(!this.localStream) {
+      throw new Error("No stream defined")
+    }
+    switch(type){
+      case 'video':
+        return this.localStream.getVideoTracks()
+      case 'audio':
+        return this.localStream.getAudioTracks()
+      case 'all':
+        return this.localStream.getTracks()
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensyn-robotics/wowza-webrtc-client",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "WoWza WebRTC Player/Client.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Idea
This PR is for exposing mediatracks inside the localstream of publisher

- since gettracks api is in experimental, when getting the tracks specify the `kind`

## link
* https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/getTracks